### PR TITLE
Add basic dynamicstore wrapper

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,11 @@
+# Activation of features, almost objectively better ;)
+reorder_imports = true
+reorder_imported_names = true
+reorder_imports_in_group = true
+use_try_shorthand = true
+condense_wildcard_suffices = true
+normalize_comments = true
+wrap_comments = true
+
+# Heavily subjective style choices
+comment_width = 100

--- a/system-configuration-sys/Cargo.toml
+++ b/system-configuration-sys/Cargo.toml
@@ -10,8 +10,8 @@ license = "MIT/Apache-2.0"
 build = "build.rs"
 
 [dependencies]
-core-foundation = "0.4"
-core-foundation-sys = "0.4"
+core-foundation = { git = "https://github.com/servo/core-foundation-rs", version = "0.4.4" }
+core-foundation-sys = { git = "https://github.com/servo/core-foundation-rs", version = "0.4.4" }
 
 [build-dependencies]
 bindgen = "0.31"

--- a/system-configuration-sys/Cargo.toml
+++ b/system-configuration-sys/Cargo.toml
@@ -10,7 +10,6 @@ license = "MIT/Apache-2.0"
 build = "build.rs"
 
 [dependencies]
-core-foundation = { git = "https://github.com/servo/core-foundation-rs", version = "0.4.4" }
 core-foundation-sys = { git = "https://github.com/servo/core-foundation-rs", version = "0.4.4" }
 
 [build-dependencies]

--- a/system-configuration/Cargo.toml
+++ b/system-configuration/Cargo.toml
@@ -9,3 +9,7 @@ repository = "https://github.com/mullvad/system-configuration-rs"
 license = "MIT/Apache-2.0"
 
 [dependencies]
+core-foundation = { git = "https://github.com/servo/core-foundation-rs", version = "0.4.4" }
+core-foundation-sys = { git = "https://github.com/servo/core-foundation-rs", version = "0.4.4" }
+
+system-configuration-sys = { path = "../system-configuration-sys" }

--- a/system-configuration/src/bin/set_dns.rs
+++ b/system-configuration/src/bin/set_dns.rs
@@ -1,0 +1,44 @@
+extern crate system_configuration;
+extern crate system_configuration_sys;
+
+extern crate core_foundation;
+extern crate core_foundation_sys;
+
+use core_foundation::array::CFArray;
+use core_foundation::base::TCFType;
+use core_foundation::dictionary::CFDictionary;
+use core_foundation::string::{CFString, CFStringRef};
+
+use system_configuration::dynamic_store::SCDynamicStore;
+
+fn main() {
+    unsafe {
+        let store = SCDynamicStore::create("my-test-dyn-store");
+        println!("Created dynamic store");
+
+        let ipv4_dict = store
+            .get("State:/Network/Global/IPv4")
+            .expect("Unable to find global settings");
+        println!("Got IPv4 global property list");
+
+        let pri_service_id_ptr = ipv4_dict
+            .find2(&CFString::from_static_string("PrimaryService"))
+            .expect("No PrimaryService");
+        let pri_service_id = CFString::wrap_under_get_rule(pri_service_id_ptr as CFStringRef);
+
+        let pri_service_path =
+            CFString::new(&format!("State:/Network/Service/{}/DNS", pri_service_id));
+        println!("PrimaryService path: {}", pri_service_path);
+
+        let server_addresses_key = CFString::from_static_string("ServerAddresses");
+        let server_addresses_value = CFArray::from_CFTypes(&[
+            CFString::from_static_string("8.8.8.8"),
+            CFString::from_static_string("8.8.4.4"),
+        ]);
+        let dns_dictionary =
+            CFDictionary::from_CFType_pairs(&[(server_addresses_key, server_addresses_value)]);
+
+        let success = store.set(pri_service_path, &dns_dictionary);
+        println!("success? {}", success);
+    }
+}

--- a/system-configuration/src/bin/set_dns.rs
+++ b/system-configuration/src/bin/set_dns.rs
@@ -18,7 +18,9 @@ fn main() {
 
         let ipv4_dict = store
             .get("State:/Network/Global/IPv4")
-            .expect("Unable to find global settings");
+            .expect("Unable to find global settings")
+            .downcast::<_, CFDictionary>()
+            .expect("Global IPv4 settings not a dictionary");
         println!("Got IPv4 global property list");
 
         let pri_service_id_ptr = ipv4_dict

--- a/system-configuration/src/dynamic_store.rs
+++ b/system-configuration/src/dynamic_store.rs
@@ -1,0 +1,101 @@
+// Copyright 2017 Amagicom AB.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use core_foundation::base::TCFType;
+use core_foundation::boolean::CFBoolean;
+use core_foundation::dictionary::{CFDictionary, CFDictionaryRef};
+use core_foundation::string::CFString;
+use core_foundation_sys::base::{CFRelease, kCFAllocatorDefault};
+use core_foundation_sys::propertylist::CFPropertyListRef;
+
+use system_configuration_sys::dynamic_store::*;
+
+use std::ptr;
+
+/// Access to the key-value pairs in the dynamic store of a running system.
+pub struct SCDynamicStore(SCDynamicStoreRef);
+
+impl Drop for SCDynamicStore {
+    fn drop(&mut self) {
+        unsafe { CFRelease(self.as_CFTypeRef()) }
+    }
+}
+
+impl_TCFType!(SCDynamicStore, SCDynamicStoreRef, SCDynamicStoreGetTypeID);
+
+impl SCDynamicStore {
+    /// Creates a new session used to interact with the dynamic store maintained by the System
+    /// Configuration server.
+    pub fn create<S: Into<CFString>>(name: S) -> Self {
+        let cf_name = name.into();
+        unsafe {
+            let store = SCDynamicStoreCreate(
+                kCFAllocatorDefault,
+                cf_name.as_concrete_TypeRef(),
+                None,
+                ptr::null_mut(),
+            );
+            SCDynamicStore::wrap_under_create_rule(store)
+        }
+    }
+
+    /// Creates a new session used to interact with the dynamic store maintained by the System
+    /// Configuration server. Uses [`SCDynamicStoreCreateWithOptions`] underneath and sets
+    /// `kSCDynamicStoreUseSessionKeys` to true.
+    ///
+    /// [`SCDynamicStoreCreateWithOptions`]: https://developer.apple.com/documentation/systemconfiguration/1437818-scdynamicstorecreatewithoptions?language=objc
+    pub fn create_with_session_keys<S: Into<CFString>>(name: S) -> Self {
+        let cf_name = name.into();
+        unsafe {
+            let store_options = CFDictionary::from_CFType_pairs(&[
+                (
+                    CFString::wrap_under_create_rule(kSCDynamicStoreUseSessionKeys),
+                    CFBoolean::true_value(),
+                ),
+            ]);
+            let store = SCDynamicStoreCreateWithOptions(
+                kCFAllocatorDefault,
+                cf_name.as_concrete_TypeRef(),
+                store_options.as_concrete_TypeRef(),
+                None,
+                ptr::null_mut(),
+            );
+            SCDynamicStore::wrap_under_create_rule(store)
+        }
+    }
+
+    /// If the given key exists in the store, the associated value is returned.
+    pub fn get<S: Into<CFString>>(&self, key: S) -> Option<CFDictionary> {
+        let cf_key = key.into();
+        unsafe {
+            let dict_ref =
+                SCDynamicStoreCopyValue(self.as_concrete_TypeRef(), cf_key.as_concrete_TypeRef());
+            if dict_ref != ptr::null() {
+                Some(CFDictionary::wrap_under_create_rule(
+                    dict_ref as *const _ as CFDictionaryRef,
+                ))
+            } else {
+                None
+            }
+        }
+    }
+
+    /// Sets the value of the given key. Overwrites existing values.
+    /// Returns `true` on success, false on failure.
+    pub fn set<S: Into<CFString>>(&self, key: S, value: &CFDictionary) -> bool {
+        let cf_key = key.into();
+        let success = unsafe {
+            SCDynamicStoreSetValue(
+                self.as_concrete_TypeRef(),
+                cf_key.as_concrete_TypeRef(),
+                value.as_concrete_TypeRef() as CFPropertyListRef,
+            )
+        };
+        success != 0
+    }
+}

--- a/system-configuration/src/lib.rs
+++ b/system-configuration/src/lib.rs
@@ -1,7 +1,6 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}
+#[macro_use]
+extern crate core_foundation;
+extern crate core_foundation_sys;
+extern crate system_configuration_sys;
+
+pub mod dynamic_store;


### PR DESCRIPTION
Adding a formatter settings file. Same as we have everywhere else.

Depending on git version of `core-foundations`. Because it has a number of patches merged that I created to make some things easier/possible to implement in system configuration. Not sure when/if they will release an upgrade. But at this early stage of playing with system configuration it does not matter if we depend on a git version IMO.

Adding the base `SCDynamicStore` functionality. This version can get and set values in the store. Please audit this carefully for memory correctness. There are more features coming to this struct. But I wanted to keep it simple in first PR, to correctly audit the base of it.

I added a temporary bin, `set_dns`, that uses this new struct to read out the primary interface and set the DNS of it to `8.8.8.8` and `8.8.4.4` so this code can be tested and played with.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/system-configuration-rs/2)
<!-- Reviewable:end -->
