### PR TITLE
Add dynamic store callback support

### DIFF
--- a/system-configuration-sys/Cargo.toml
+++ b/system-configuration-sys/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT/Apache-2.0"
 build = "build.rs"
 
 [dependencies]
-core-foundation-sys = { git = "https://github.com/servo/core-foundation-rs", version = "0.4.4" }
+core-foundation-sys = "0.4.6"
 
 [build-dependencies]
 bindgen = "0.31"

--- a/system-configuration/Cargo.toml
+++ b/system-configuration/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/mullvad/system-configuration-rs"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-core-foundation = { git = "https://github.com/servo/core-foundation-rs", version = "0.4.4" }
-core-foundation-sys = { git = "https://github.com/servo/core-foundation-rs", version = "0.4.4" }
+core-foundation = "0.4.6"
+core-foundation-sys = "0.4.6"
 
-system-configuration-sys = { path = "../system-configuration-sys" }
+system-configuration-sys = { path = "../system-configuration-sys", version = "0.1" }

--- a/system-configuration/src/bin/set_dns.rs
+++ b/system-configuration/src/bin/set_dns.rs
@@ -9,11 +9,11 @@ use core_foundation::base::TCFType;
 use core_foundation::dictionary::CFDictionary;
 use core_foundation::string::{CFString, CFStringRef};
 
-use system_configuration::dynamic_store::SCDynamicStore;
+use system_configuration::dynamic_store::SCDynamicStoreBuilder;
 
 fn main() {
     unsafe {
-        let store = SCDynamicStore::create("my-test-dyn-store");
+        let store = SCDynamicStoreBuilder::new("my-test-dyn-store").build();
         println!("Created dynamic store");
 
         let ipv4_dict = store

--- a/system-configuration/src/bin/watch_dns.rs
+++ b/system-configuration/src/bin/watch_dns.rs
@@ -1,0 +1,85 @@
+extern crate system_configuration;
+extern crate system_configuration_sys;
+
+extern crate core_foundation;
+extern crate core_foundation_sys;
+
+
+use core_foundation::array::CFArray;
+use core_foundation::dictionary::CFDictionary;
+use core_foundation::runloop::CFRunLoop;
+use core_foundation::string::CFString;
+use core_foundation_sys::runloop::kCFRunLoopCommonModes;
+
+use system_configuration::dynamic_store::{SCDynamicStore, SCDynamicStoreBuilder,
+                                          SCDynamicStoreCallBackContext};
+
+use std::env;
+
+#[derive(Debug)]
+struct Payload {
+    i: u64,
+    service_path: CFString,
+}
+
+impl Drop for Payload {
+    fn drop(&mut self) {
+        println!("Payload Drop");
+    }
+}
+
+fn main() {
+    let service_id = env::args()
+        .skip(1)
+        .next()
+        .expect("Give service uuid as first argument");
+    let service_path = CFString::from(&format!("State:/Network/Service/{}/DNS", service_id)[..]);
+
+    let watch_keys = CFArray::from_CFTypes(&[service_path.clone()]);
+    let watch_patterns: CFArray<CFString> = CFArray::from_CFTypes(&[]);
+
+    let callback_context = SCDynamicStoreCallBackContext {
+        callout: my_callback,
+        info: Payload {
+            i: 0,
+            service_path: service_path,
+        },
+    };
+
+    let store = SCDynamicStoreBuilder::new("my-watch-dns-store")
+        .callback_context(callback_context)
+        .build();
+    println!("Created dynamic store");
+
+    if store.set_notification_keys(&watch_keys, &watch_patterns) {
+        println!("Registered for notifications");
+    } else {
+        panic!("Unable to register notifications");
+    }
+    let run_loop_source = store.create_run_loop_source();
+
+    let run_loop = CFRunLoop::get_current();
+    run_loop.add_source(&run_loop_source, unsafe { kCFRunLoopCommonModes });
+    println!("Entering run loop");
+    CFRunLoop::run_current();
+}
+
+fn my_callback(store: SCDynamicStore, _changed_keys: CFArray<CFString>, payload: &mut Payload) {
+    println!("my_callback2 (payload: {:?})", payload);
+    payload.i += 1;
+
+    if payload.i > 1 {
+        // Only reset DNS on first callback for now. To not get stuck in infinite loop.
+        return;
+    }
+
+    let server_addresses_key = CFString::from_static_string("ServerAddresses");
+    let server_address_1 = CFString::from_static_string("192.168.1.1");
+    let server_addresses_value = CFArray::from_CFTypes(&[server_address_1]);
+
+    let dns_dictionary =
+        CFDictionary::from_CFType_pairs(&[(server_addresses_key, server_addresses_value)]);
+
+    let success = store.set(payload.service_path.clone(), &dns_dictionary);
+    println!("callback: {}", success);
+}

--- a/system-configuration/src/dynamic_store.rs
+++ b/system-configuration/src/dynamic_store.rs
@@ -208,6 +208,14 @@ impl SCDynamicStore {
         success != 0
     }
 
+    pub fn remove<S: Into<CFString>>(&self, key: S) -> bool {
+        let cf_key = key.into();
+        let success = unsafe {
+            SCDynamicStoreRemoveValue(self.as_concrete_TypeRef(), cf_key.as_concrete_TypeRef())
+        };
+        success != 0
+    }
+
     /// Specifies a set of keys and key patterns that should be monitored for changes.
     pub fn set_notification_keys<T1, T2>(
         &self,


### PR DESCRIPTION
Add support for notification callbacks from `SCDynamicStore`.

Now when the construction of the `SCDynamicStore` session requires two parameters (session store or not plus have callbacks or not) with a total of four combinations, it did not feel feasible to have dedicated constructors. With the builder I introduce here it's possible to easily create all four combinations.

Upgrading the `core-foundation` dependency since I got a lot of useful/necessary stuff merged there since last time.

The `watch_dns` binary is just temporary to showcase the functionality. It watches one service interface for DNS changes and when it's changed it sets the DNS again. Kind of in an ugly way now, but it's just to show the feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/system-configuration-rs/3)
<!-- Reviewable:end -->
