### PR TITLE
Add get_keys method to SCDynamicStore

### DIFF
--- a/system-configuration/src/dynamic_store.rs
+++ b/system-configuration/src/dynamic_store.rs
@@ -168,6 +168,25 @@ impl SCDynamicStore {
         }
     }
 
+    /// Returns the keys that represent the current dynamic store entries that match the specified
+    /// pattern. Or `None` if an error occured.
+    ///
+    /// `pattern` - A regular expression pattern used to match the dynamic store keys.
+    pub fn get_keys<S: Into<CFString>>(&self, pattern: S) -> Option<CFArray<CFString>> {
+        let cf_pattern = pattern.into();
+        unsafe {
+            let array_ref = SCDynamicStoreCopyKeyList(
+                self.as_concrete_TypeRef(),
+                cf_pattern.as_concrete_TypeRef(),
+            );
+            if array_ref != ptr::null() {
+                Some(CFArray::wrap_under_create_rule(array_ref))
+            } else {
+                None
+            }
+        }
+    }
+
     /// If the given key exists in the store, the associated value is returned.
     ///
     /// Use `CFPropertyList::downcast` to cast the result into the correct type.


### PR DESCRIPTION
I had to list all keys for DNS settings, so I had to add this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/system-configuration-rs/4)
<!-- Reviewable:end -->
