### PR TITLE
Add travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: rust
+cache: cargo
+rust:
+  - nightly
+  - stable
+  - beta
+os:
+  - osx
+
+
+before_script:
+  - rustup component add rustfmt-preview
+  - rustfmt --version
+
+script:
+  - cargo build --verbose
+  - cargo test --verbose
+  - if [ "${TRAVIS_RUST_VERSION}" = "nightly" ]; then
+      cargo fmt -- --write-mode=diff;
+    else
+      echo "Not checking formatting on this build";
+    fi
+
+notifications:
+  email:
+    on_success: never
+    on_failure: never

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,5 @@
+required_version = "0.3.8"
+
 # Activation of features, almost objectively better ;)
 reorder_imports = true
 reorder_imported_names = true
@@ -9,3 +11,4 @@ wrap_comments = true
 
 # Heavily subjective style choices
 comment_width = 100
+blank_lines_upper_bound = 2


### PR DESCRIPTION
I realized we did not run this library on Travis. If we start taking in third party contributions it's really good to have a CI, so contributors can iterate by themselves until our CI accepts the change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/system-configuration-rs/10)
<!-- Reviewable:end -->
