### PR TITLE
Deny missing documentation

### DIFF
--- a/system-configuration/src/dynamic_store.rs
+++ b/system-configuration/src/dynamic_store.rs
@@ -221,6 +221,7 @@ impl SCDynamicStore {
         success != 0
     }
 
+    /// Removes the value of the specified key from the dynamic store.
     pub fn remove<S: Into<CFString>>(&self, key: S) -> bool {
         let cf_key = key.into();
         let success = unsafe {

--- a/system-configuration/src/lib.rs
+++ b/system-configuration/src/lib.rs
@@ -17,6 +17,8 @@
 //! [SystemConfiguration]: https://developer.apple.com/documentation/systemconfiguration?language=objc
 //! [`system-configuration-sys`]: https://crates.io/crates/system-configuration-sys
 
+#![deny(missing_docs)]
+
 #[macro_use]
 extern crate core_foundation;
 extern crate system_configuration_sys;


### PR DESCRIPTION
Add directive to fail compilation if a publicly accessible item is missing documentation. Also add documentation to the only item missing it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/system-configuration-rs/11)
<!-- Reviewable:end -->
