### PR TITLE
Add preferences abstraction

### DIFF
--- a/system-configuration/src/lib.rs
+++ b/system-configuration/src/lib.rs
@@ -24,3 +24,4 @@ extern crate core_foundation;
 extern crate system_configuration_sys;
 
 pub mod dynamic_store;
+pub mod preferences;

--- a/system-configuration/src/preferences.rs
+++ b/system-configuration/src/preferences.rs
@@ -1,0 +1,49 @@
+// Copyright 2017 Amagicom AB.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Bindings to [`SCPreferences`].
+//!
+//! See the examples directory for examples how to use this module.
+//!
+//! [`SCPreferences`]: https://developer.apple.com/documentation/systemconfiguration/scpreferences
+
+
+use core_foundation::base::CFAllocatorRef;
+use core_foundation::base::TCFType;
+use core_foundation::string::CFString;
+
+pub use system_configuration_sys::preferences::*;
+
+use std::ptr;
+
+
+declare_TCFType!{
+    /// The handle to an open preferences session for accessing system configuration preferences.
+    SCPreferences, SCPreferencesRef
+}
+
+impl_TCFType!(SCPreferences, SCPreferencesRef, SCPreferencesGetTypeID);
+
+
+impl SCPreferences {
+    /// Initiates access to the per-system set of configuration preferences.
+    pub fn new(allocator: CFAllocatorRef, name: &str, prefs_id: Option<&str>) -> Self {
+        let prefs_id = match prefs_id {
+            Some(prefs_id) => CFString::new(prefs_id).as_concrete_TypeRef(),
+            None => ptr::null(),
+        };
+
+        unsafe {
+            SCPreferences::wrap_under_get_rule(SCPreferencesCreate(
+                allocator,
+                CFString::new(name).as_concrete_TypeRef(),
+                prefs_id,
+            ))
+        }
+    }
+}

--- a/system-configuration/src/preferences.rs
+++ b/system-configuration/src/preferences.rs
@@ -10,7 +10,7 @@
 //!
 //! See the examples directory for examples how to use this module.
 //!
-//! [`SCPreferences`]: https://developer.apple.com/documentation/systemconfiguration/scpreferences
+//! [`SCPreferences`]: https://developer.apple.com/documentation/systemconfiguration/scpreferences-ft8
 
 
 use core_foundation::base::{CFAllocatorRef, TCFType};
@@ -45,7 +45,10 @@ impl SCPreferences {
     }
 
     /// Initiates access to the per-system set of configuration preferences with a given
-    /// allocator and preference group to access.
+    /// allocator and preference group to access. See the underlying [SCPreferencesCreate] function
+    /// documentation for details.
+    ///
+    /// [SCPreferencesCreate]: https://developer.apple.com/documentation/systemconfiguration/1516807-scpreferencescreate?language=objc
     pub fn with_allocator(
         allocator: CFAllocatorRef,
         calling_process_name: &CFString,

--- a/system-configuration/src/preferences.rs
+++ b/system-configuration/src/preferences.rs
@@ -57,11 +57,23 @@ impl SCPreferences {
         };
 
         unsafe {
-            SCPreferences::wrap_under_get_rule(SCPreferencesCreate(
+            SCPreferences::wrap_under_create_rule(SCPreferencesCreate(
                 allocator,
                 calling_process_name.as_concrete_TypeRef(),
                 prefs_id_ptr,
             ))
         }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retain_count() {
+        let preferences = SCPreferences::default(&CFString::new("test"));
+        assert_eq!(preferences.retain_count(), 1);
     }
 }


### PR DESCRIPTION
PR #8 was growing quite a lot. So I felt like splitting out some of the code for separate review in order to shrink that PR a bit.

This PR introduces the safe abstraction for `SCPreferences`. The first commit is the code from @luozijun that I cherry picked from the other PR branch.  The second commit is where I add some simplifying constructors making it easier to construct the type for the most common use case.

@luozijun please add your feedback to this as well.

Please note that all constructors take `&CFString` instead of `&str`. This is in line with how we have done in `dynamic_store.rs` and also with how other crates implementing Apple APIs usually do. Example: https://docs.rs/core-graphics/0.13.0/core_graphics/font/struct.CGFont.html#method.from_name

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/system-configuration-rs/12)
<!-- Reviewable:end -->
