### PR TITLE
Update travis and changelog

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,13 @@ rust:
   - nightly
   - stable
   - beta
+  - 1.20.0
 os:
   - osx
 
 script:
-  - cargo build --verbose
-  - cargo test --verbose
+  - cargo build --all --verbose
+  - cargo test --all --verbose
   - if [ "${TRAVIS_RUST_VERSION}" = "nightly" ]; then
       rustup component add rustfmt-preview;
       rustfmt --version;

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,19 +7,17 @@ rust:
 os:
   - osx
 
-
-before_script:
-  - rustup component add rustfmt-preview
-  - rustfmt --version
-
 script:
   - cargo build --verbose
   - cargo test --verbose
   - if [ "${TRAVIS_RUST_VERSION}" = "nightly" ]; then
-      cargo fmt -- --write-mode=diff;
+      rustup component add rustfmt-preview;
+      rustfmt --version;
+      cargo fmt -- --check --unstable-features;
     else
       echo "Not checking formatting on this build";
     fi
+
 
 notifications:
   email:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+All changes to the software that can be noticed from the users' perspective should have an entry in
+this file.
+
+### Format
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+
+Entries should have the imperative form, just like commit messages. Start each entry with words like
+add, fix, increase, force etc.. Not added, fixed, increased, forced etc.
+
+Line wrap the file at 100 chars.                                              That is over here -> |
+
+### Categories each change fall into
+
+* **Added**: for new features.
+* **Changed**: for changes in existing functionality.
+* **Deprecated**: for soon-to-be removed features.
+* **Removed**: for now removed features.
+* **Fixed**: for any bug fixes.
+* **Security**: in case of vulnerabilities.
+
+
+## [Unreleased]
+### Added
+- Publicly re-export `libc` and `core_foundation_sys` from `system_configuration_sys`.
+- Add low level FFI bindings to SCPreferences and SCNetworkConfiguration.
+- Add bare minimal safe high level SCPreferences type.
+
+### Changed
+- Make `system_configuration_sys` a `#[no_std]` crate.
+
+
+## [0.1.0] - 2018-02-01
+### Added
+- Initial release. Supports most SCDynamicStore operations.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,9 +1,4 @@
-required_version = "0.3.8"
-
 # Activation of features, almost objectively better ;)
-reorder_imports = true
-reorder_imported_names = true
-reorder_imports_in_group = true
 use_try_shorthand = true
 condense_wildcard_suffixes = true
 normalize_comments = true

--- a/system-configuration/examples/watch_dns.rs
+++ b/system-configuration/examples/watch_dns.rs
@@ -6,11 +6,12 @@ use core_foundation::array::CFArray;
 use core_foundation::base::{CFType, TCFType};
 use core_foundation::dictionary::CFDictionary;
 use core_foundation::propertylist::CFPropertyList;
-use core_foundation::runloop::{CFRunLoop, kCFRunLoopCommonModes};
+use core_foundation::runloop::{kCFRunLoopCommonModes, CFRunLoop};
 use core_foundation::string::CFString;
 
-use system_configuration::dynamic_store::{SCDynamicStore, SCDynamicStoreBuilder,
-                                          SCDynamicStoreCallBackContext};
+use system_configuration::dynamic_store::{
+    SCDynamicStore, SCDynamicStoreBuilder, SCDynamicStoreCallBackContext,
+};
 
 // This example will watch the dynamic store for changes to any DNS setting. As soon as a change
 // is detected, it will be printed to stdout.

--- a/system-configuration/src/dynamic_store.rs
+++ b/system-configuration/src/dynamic_store.rs
@@ -13,7 +13,7 @@
 //! [`SCDynamicStore`]: https://developer.apple.com/documentation/systemconfiguration/scdynamicstore?language=objc
 
 use core_foundation::array::{CFArray, CFArrayRef};
-use core_foundation::base::{TCFType, kCFAllocatorDefault};
+use core_foundation::base::{kCFAllocatorDefault, TCFType};
 use core_foundation::boolean::CFBoolean;
 use core_foundation::dictionary::CFDictionary;
 use core_foundation::propertylist::{CFPropertyList, CFPropertyListSubClass};


### PR DESCRIPTION
I was going to look into upgrading our `core-foundation` dependency to `0.6`. But I ran into other things to fix first. So this PR tries to bring the repository up to the latest standard for how we try to do stuff in libraries.

* Having a changelog
* Running Travis towards the minimum supported version of rustc

I also synchronized the rustfmt settings with our latest template and reformatted with it.