### PR TITLE
Upgrade core-foundation to 0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Line wrap the file at 100 chars.                                              Th
 - Publicly re-export `system_configuration_sys` as `system_configuration::sys` instead of
   re-exporting each sys module under their corresponding safe level module.
 - Raise minimum Rust version to 1.25 in order to use nested import groups.
+- Upgrade `core-foundation` dependency from 0.5 to 0.6.
 
 
 ## [0.1.0] - 2018-02-01

--- a/system-configuration-sys/Cargo.toml
+++ b/system-configuration-sys/Cargo.toml
@@ -9,5 +9,5 @@ repository = "https://github.com/mullvad/system-configuration-rs"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-core-foundation-sys = "0.5"
+core-foundation-sys = "0.6"
 libc = "0.2"

--- a/system-configuration/Cargo.toml
+++ b/system-configuration/Cargo.toml
@@ -10,6 +10,5 @@ license = "MIT/Apache-2.0"
 readme = "../README.md"
 
 [dependencies]
-core-foundation = "0.5"
-
+core-foundation = "0.6"
 system-configuration-sys = { path = "../system-configuration-sys", version = "0.1" }

--- a/system-configuration/src/dynamic_store.rs
+++ b/system-configuration/src/dynamic_store.rs
@@ -119,7 +119,8 @@ impl<T> SCDynamicStoreBuilder<T> {
     fn create_store_options(&self) -> CFDictionary {
         let key = unsafe { CFString::wrap_under_create_rule(kSCDynamicStoreUseSessionKeys) };
         let value = CFBoolean::from(self.session_keys);
-        CFDictionary::from_CFType_pairs(&[(key, value)])
+        let typed_dict = CFDictionary::from_CFType_pairs(&[(key, value)]);
+        unsafe { CFDictionary::wrap_under_get_rule(typed_dict.as_concrete_TypeRef()) }
     }
 
     fn create_context(


### PR DESCRIPTION
`core-foundation 0.6` has been out for quite a while. It adds better interfacing to dictionaries for example. In general it wraps the underlying unsafe API safer and more ergonomic.

I also started using the schema definition constants from the new `schema_definitions` module in the examples.