### PR TITLE
Fix clippy lints and activate clippy on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ script:
     else
       echo "Not checking formatting on this build";
     fi
+  - if rustup component add clippy; then
+      cargo clippy --all-targets -- --deny warnings;
+    fi
 
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: rust
 cache: cargo
 rust:
+  - 1.30.0
   - nightly
   - stable
   - beta
-  - 1.30.0
 os:
   - osx
 

--- a/system-configuration/src/dynamic_store.rs
+++ b/system-configuration/src/dynamic_store.rs
@@ -198,7 +198,7 @@ impl SCDynamicStore {
     pub fn get_proxies(&self) -> Option<CFDictionary<CFString, CFType>> {
         unsafe {
             let dictionary_ref = SCDynamicStoreCopyProxies(self.as_concrete_TypeRef());
-            if dictionary_ref != ptr::null() {
+            if !dictionary_ref.is_null() {
                 Some(CFDictionary::wrap_under_create_rule(dictionary_ref))
             } else {
                 None


### PR DESCRIPTION
There were some new code merged very recently that was not optimal according to clippy. So I went ahead and fixed that. I then also felt we could activate automatic clippy run on our CI. So we, and external contributors are reminded to fix these smells before they land in master at all.

Here I activate clippy on its most strict setting, causing a CI error for any lint warning. But since we obviously have that level of quality on this code now we might just as well try to keep it. This is sort of an experiment. If this turns out quite fine we can activate it on other repos we have. Ultimately it would be good to follow clippy's advice everywhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/system-configuration-rs/19)
<!-- Reviewable:end -->
