### PR TITLE
Upgrade to Rust 2018 edition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 cache: cargo
 rust:
-  - 1.30.0
+  - 1.31.0
   - nightly
   - stable
   - beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 - Use `core::ffi::c_void` instead of `libc::c_void` (new minimum supported Rust version: 1.30).
 - Define some ffi types as `struct TheType(c_void)` instead of `type TheType = c_void`.
+- Upgrade crates to Rust 2018 edition, increasing minimum supported Rust version to 1.31
 
 
 ## [0.2.0] - 2018-10-23

--- a/system-configuration-sys/Cargo.toml
+++ b/system-configuration-sys/Cargo.toml
@@ -7,6 +7,7 @@ keywords = ["macos", "system", "configuration", "bindings"]
 categories = ["external-ffi-bindings", "os::macos-apis"]
 repository = "https://github.com/mullvad/system-configuration-rs"
 license = "MIT/Apache-2.0"
+edition = "2018"
 
 [dependencies]
 core-foundation-sys = "0.6"

--- a/system-configuration-sys/src/dynamic_store.rs
+++ b/system-configuration-sys/src/dynamic_store.rs
@@ -12,7 +12,7 @@ use core_foundation_sys::propertylist::CFPropertyListRef;
 use core_foundation_sys::runloop::CFRunLoopSourceRef;
 use core_foundation_sys::string::CFStringRef;
 
-use dispatch_queue_t;
+use crate::dispatch_queue_t;
 
 #[repr(C)]
 pub struct __SCDynamicStore(c_void);

--- a/system-configuration-sys/src/dynamic_store_copy_specific.rs
+++ b/system-configuration-sys/src/dynamic_store_copy_specific.rs
@@ -4,9 +4,9 @@
 // bindgen 0.51.1
 // macOS SDK 10.15.
 
+use crate::dynamic_store::SCDynamicStoreRef;
 use core_foundation_sys::dictionary::CFDictionaryRef;
 use core_foundation_sys::string::{CFStringEncoding, CFStringRef};
-use crate::dynamic_store::SCDynamicStoreRef;
 
 use libc::c_uint;
 

--- a/system-configuration-sys/src/dynamic_store_copy_specific.rs
+++ b/system-configuration-sys/src/dynamic_store_copy_specific.rs
@@ -6,7 +6,7 @@
 
 use core_foundation_sys::dictionary::CFDictionaryRef;
 use core_foundation_sys::string::{CFStringEncoding, CFStringRef};
-use dynamic_store::SCDynamicStoreRef;
+use crate::dynamic_store::SCDynamicStoreRef;
 
 use libc::c_uint;
 

--- a/system-configuration-sys/src/lib.rs
+++ b/system-configuration-sys/src/lib.rs
@@ -17,8 +17,8 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_snake_case)]
 
-pub extern crate core_foundation_sys;
-pub extern crate libc;
+pub use core_foundation_sys;
+pub use libc;
 
 /// This is a temporary solution.
 pub type dispatch_queue_t = *mut libc::c_void;

--- a/system-configuration-sys/src/network_configuration.rs
+++ b/system-configuration-sys/src/network_configuration.rs
@@ -11,9 +11,9 @@ use core_foundation_sys::dictionary::CFDictionaryRef;
 use core_foundation_sys::runloop::CFRunLoopRef;
 use core_foundation_sys::string::CFStringRef;
 
-use dispatch_queue_t;
+use crate::dispatch_queue_t;
 use libc::{c_char, c_int, sockaddr, socklen_t};
-use preferences::SCPreferencesRef;
+use crate::preferences::SCPreferencesRef;
 
 pub type __SCNetworkReachability = c_void;
 pub type __SCNetworkConnection = c_void;

--- a/system-configuration-sys/src/network_configuration.rs
+++ b/system-configuration-sys/src/network_configuration.rs
@@ -12,8 +12,8 @@ use core_foundation_sys::runloop::CFRunLoopRef;
 use core_foundation_sys::string::CFStringRef;
 
 use crate::dispatch_queue_t;
-use libc::{c_char, c_int, sockaddr, socklen_t};
 use crate::preferences::SCPreferencesRef;
+use libc::{c_char, c_int, sockaddr, socklen_t};
 
 pub type __SCNetworkReachability = c_void;
 pub type __SCNetworkConnection = c_void;

--- a/system-configuration-sys/src/preferences.rs
+++ b/system-configuration-sys/src/preferences.rs
@@ -12,7 +12,7 @@ use core_foundation_sys::propertylist::CFPropertyListRef;
 use core_foundation_sys::runloop::CFRunLoopRef;
 use core_foundation_sys::string::CFStringRef;
 
-use dispatch_queue_t;
+use crate::dispatch_queue_t;
 
 pub type AuthorizationOpaqueRef = c_void;
 pub type __SCPreferences = c_void;

--- a/system-configuration/Cargo.toml
+++ b/system-configuration/Cargo.toml
@@ -8,6 +8,7 @@ categories = ["api-bindings", "os::macos-apis"]
 repository = "https://github.com/mullvad/system-configuration-rs"
 license = "MIT/Apache-2.0"
 readme = "../README.md"
+edition = "2018"
 
 [dependencies]
 core-foundation = "0.6"

--- a/system-configuration/examples/set_dns.rs
+++ b/system-configuration/examples/set_dns.rs
@@ -1,7 +1,3 @@
-extern crate system_configuration;
-
-extern crate core_foundation;
-
 use core_foundation::{
     array::CFArray,
     base::{TCFType, ToVoid},

--- a/system-configuration/examples/watch_dns.rs
+++ b/system-configuration/examples/watch_dns.rs
@@ -49,6 +49,8 @@ struct Context {
     call_count: u64,
 }
 
+
+#[allow(clippy::needless_pass_by_value)]
 fn my_callback(store: SCDynamicStore, changed_keys: CFArray<CFString>, context: &mut Context) {
     context.call_count += 1;
     println!("Callback call count: {}", context.call_count);

--- a/system-configuration/examples/watch_dns.rs
+++ b/system-configuration/examples/watch_dns.rs
@@ -1,6 +1,3 @@
-extern crate core_foundation;
-extern crate system_configuration;
-
 use core_foundation::{
     array::CFArray,
     base::{CFType, TCFType, ToVoid},

--- a/system-configuration/src/dynamic_store.rs
+++ b/system-configuration/src/dynamic_store.rs
@@ -22,7 +22,7 @@ use core_foundation::{
     string::CFString,
 };
 use std::{ffi::c_void, ptr};
-use sys::{
+use crate::sys::{
     dynamic_store::{
         kSCDynamicStoreUseSessionKeys, SCDynamicStoreCallBack, SCDynamicStoreContext,
         SCDynamicStoreCopyKeyList, SCDynamicStoreCopyValue, SCDynamicStoreCreateRunLoopSource,

--- a/system-configuration/src/dynamic_store.rs
+++ b/system-configuration/src/dynamic_store.rs
@@ -12,6 +12,15 @@
 //!
 //! [`SCDynamicStore`]: https://developer.apple.com/documentation/systemconfiguration/scdynamicstore?language=objc
 
+use crate::sys::{
+    dynamic_store::{
+        kSCDynamicStoreUseSessionKeys, SCDynamicStoreCallBack, SCDynamicStoreContext,
+        SCDynamicStoreCopyKeyList, SCDynamicStoreCopyValue, SCDynamicStoreCreateRunLoopSource,
+        SCDynamicStoreCreateWithOptions, SCDynamicStoreGetTypeID, SCDynamicStoreRef,
+        SCDynamicStoreRemoveValue, SCDynamicStoreSetNotificationKeys, SCDynamicStoreSetValue,
+    },
+    dynamic_store_copy_specific::SCDynamicStoreCopyProxies,
+};
 use core_foundation::{
     array::{CFArray, CFArrayRef},
     base::{kCFAllocatorDefault, CFType, TCFType},
@@ -22,15 +31,6 @@ use core_foundation::{
     string::CFString,
 };
 use std::{ffi::c_void, ptr};
-use crate::sys::{
-    dynamic_store::{
-        kSCDynamicStoreUseSessionKeys, SCDynamicStoreCallBack, SCDynamicStoreContext,
-        SCDynamicStoreCopyKeyList, SCDynamicStoreCopyValue, SCDynamicStoreCreateRunLoopSource,
-        SCDynamicStoreCreateWithOptions, SCDynamicStoreGetTypeID, SCDynamicStoreRef,
-        SCDynamicStoreRemoveValue, SCDynamicStoreSetNotificationKeys, SCDynamicStoreSetValue,
-    },
-    dynamic_store_copy_specific::SCDynamicStoreCopyProxies,
-};
 
 /// Struct describing the callback happening when a watched value in the dynamic store is changed.
 pub struct SCDynamicStoreCallBackContext<T> {

--- a/system-configuration/src/preferences.rs
+++ b/system-configuration/src/preferences.rs
@@ -15,7 +15,7 @@
 use core_foundation::base::{CFAllocator, TCFType};
 use core_foundation::string::CFString;
 use std::ptr;
-use sys::preferences::{SCPreferencesCreate, SCPreferencesGetTypeID, SCPreferencesRef};
+use crate::sys::preferences::{SCPreferencesCreate, SCPreferencesGetTypeID, SCPreferencesRef};
 
 declare_TCFType! {
     /// The handle to an open preferences session for accessing system configuration preferences.

--- a/system-configuration/src/preferences.rs
+++ b/system-configuration/src/preferences.rs
@@ -12,10 +12,10 @@
 //!
 //! [`SCPreferences`]: https://developer.apple.com/documentation/systemconfiguration/scpreferences-ft8
 
+use crate::sys::preferences::{SCPreferencesCreate, SCPreferencesGetTypeID, SCPreferencesRef};
 use core_foundation::base::{CFAllocator, TCFType};
 use core_foundation::string::CFString;
 use std::ptr;
-use crate::sys::preferences::{SCPreferencesCreate, SCPreferencesGetTypeID, SCPreferencesRef};
 
 declare_TCFType! {
     /// The handle to an open preferences session for accessing system configuration preferences.


### PR DESCRIPTION
I was going to mention in the changelog that we bumped the MSRV to 1.30. So then I realized we were still on Rust 2015. Even though we don't have any really strong reason to move to 2018 I don't see why we should not. It was an easy change, and only increased the MSRV one version anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/system-configuration-rs/21)
<!-- Reviewable:end -->
