### PR TITLE
Update CI code formatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ os:
 script:
   - cargo build --all --verbose
   - cargo test --all --verbose
-  - if [ "${TRAVIS_RUST_VERSION}" = "nightly" ]; then
-      rustup component add rustfmt-preview;
+  - if [ "${TRAVIS_RUST_VERSION}" = "stable" ]; then
+      rustup component add rustfmt;
       rustfmt --version;
-      cargo fmt -- --check --unstable-features;
+      cargo fmt -- --check;
     else
       echo "Not checking formatting on this build";
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,14 @@
 language: rust
 cache: cargo
 rust:
-  - 1.31.0
-  - nightly
   - stable
   - beta
+  - nightly
+  - 1.31.0
 os:
   - osx
 
 script:
-  - cargo build --all --verbose
-  - cargo test --all --verbose
   - if [ "${TRAVIS_RUST_VERSION}" = "stable" ]; then
       rustup component add rustfmt;
       rustfmt --version;
@@ -20,7 +18,11 @@ script:
     fi
   - if rustup component add clippy; then
       cargo clippy --all-targets -- --deny warnings;
+    else
+      echo "Failed to install clippy. Not checking with it";
     fi
+  - cargo build --all --verbose
+  - cargo test --all --verbose
 
 
 notifications:

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,9 +1,3 @@
 # Activation of features, almost objectively better ;)
 use_try_shorthand = true
-condense_wildcard_suffixes = true
-normalize_comments = true
-wrap_comments = true
-
-# Heavily subjective style choices
-comment_width = 100
-blank_lines_upper_bound = 2
+use_field_init_shorthand = true

--- a/system-configuration-sys/src/schema_definitions.rs
+++ b/system-configuration-sys/src/schema_definitions.rs
@@ -6,7 +6,6 @@
 
 use core_foundation_sys::string::CFStringRef;
 
-
 extern "C" {
     pub static kSCResvLink: CFStringRef;
 

--- a/system-configuration/examples/watch_dns.rs
+++ b/system-configuration/examples/watch_dns.rs
@@ -49,7 +49,6 @@ struct Context {
     call_count: u64,
 }
 
-
 #[allow(clippy::needless_pass_by_value)]
 fn my_callback(store: SCDynamicStore, changed_keys: CFArray<CFString>, context: &mut Context) {
     context.call_count += 1;


### PR DESCRIPTION
Relying on `rustfmt-preview` is sketchy. It might or might not be available. Unless we really need the unstable formatting options it's way more stable to just use the stable rustfmt. This PR removes all unstable formatting options we had and adds a stable one we had in our other repos. Then I reformat the code (only removes two lines of code) and update the CI to do formatting on stable instead of nightly.

Changed the order of the jobs to make formatting and linting happen asap, since it's annoying when that's the last thing that fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/system-configuration-rs/25)
<!-- Reviewable:end -->
