### PR TITLE
Bump core-foundation to 0.9

### DIFF
--- a/system-configuration-sys/Cargo.toml
+++ b/system-configuration-sys/Cargo.toml
@@ -10,5 +10,5 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
-core-foundation-sys = "0.7"
+core-foundation-sys = "0.8"
 libc = "0.2.49"

--- a/system-configuration/Cargo.toml
+++ b/system-configuration/Cargo.toml
@@ -11,6 +11,6 @@ readme = "../README.md"
 edition = "2018"
 
 [dependencies]
-core-foundation = "0.7"
+core-foundation = "0.9"
 system-configuration-sys = { path = "../system-configuration-sys", version = "0.4" }
 bitflags = "1"


### PR DESCRIPTION
This is a feeble attempt at bumping the version of core-foundation and core-foundation-sys in hopes of reducing crashes in the offline monitor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/system-configuration-rs/29)
<!-- Reviewable:end -->
