### PR TITLE
Upgrade to Rust edition 2021

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       matrix:
         # MSRV. Not considered breaking when this has to be bumped.
         # But should be mentioned in the changelog.
-        rust: [stable, beta, nightly, 1.46.0]
+        rust: [stable, beta, nightly, 1.56.0]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Line wrap the file at 100 chars.                                              Th
 
 ## [Unreleased]
 ### Changed
-- Bump minimum supported Rust version to 1.46
+- Bump minimum supported Rust version to 1.56.0
 
 
 ## [0.4.1] - 2020-06-04

--- a/system-configuration-sys/Cargo.toml
+++ b/system-configuration-sys/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["macos", "system", "configuration", "bindings"]
 categories = ["external-ffi-bindings", "os::macos-apis"]
 repository = "https://github.com/mullvad/system-configuration-rs"
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 core-foundation-sys = "0.8"

--- a/system-configuration/Cargo.toml
+++ b/system-configuration/Cargo.toml
@@ -8,7 +8,7 @@ categories = ["api-bindings", "os::macos-apis"]
 repository = "https://github.com/mullvad/system-configuration-rs"
 license = "MIT OR Apache-2.0"
 readme = "../README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 core-foundation = "0.9"


### PR DESCRIPTION
Since we are doing a breaking change release anyway, why not just upgrade to the latest edition.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/system-configuration-rs/33)
<!-- Reviewable:end -->
