### PR TITLE
Fix callback memory leak

### DIFF
--- a/system-configuration/src/network_reachability.rs
+++ b/system-configuration/src/network_reachability.rs
@@ -314,16 +314,14 @@ impl<T: Fn(ReachabilityFlags) + Sync + Send> NetworkReachabilityCallbackContext<
 
     extern "C" fn release_context(ctx: *const c_void) {
         unsafe {
-            let _ = Arc::from_raw(ctx as *mut Self);
+            Arc::decrement_strong_count(ctx as *mut Self);
         }
     }
 
     extern "C" fn retain_context(ctx_ptr: *const c_void) -> *const c_void {
         unsafe {
-            let ctx_ref: Arc<Self> = Arc::from_raw(ctx_ptr as *const Self);
-            let new_ctx = ctx_ref.clone();
-            std::mem::forget(ctx_ref);
-            Arc::into_raw(new_ctx) as *const c_void
+            Arc::increment_strong_count(ctx_ptr as *const Self);
+            ctx_ptr
         }
     }
 }

--- a/system-configuration/src/network_reachability.rs
+++ b/system-configuration/src/network_reachability.rs
@@ -312,17 +312,13 @@ impl<T: Fn(ReachabilityFlags) + Sync + Send> NetworkReachabilityCallbackContext<
         description_ref
     }
 
-    extern "C" fn release_context(ctx: *const c_void) {
-        unsafe {
-            Arc::decrement_strong_count(ctx as *mut Self);
-        }
+    unsafe extern "C" fn release_context(ctx: *const c_void) {
+        Arc::decrement_strong_count(ctx as *mut Self);
     }
 
-    extern "C" fn retain_context(ctx_ptr: *const c_void) -> *const c_void {
-        unsafe {
-            Arc::increment_strong_count(ctx_ptr as *const Self);
-            ctx_ptr
-        }
+    unsafe extern "C" fn retain_context(ctx_ptr: *const c_void) -> *const c_void {
+        Arc::increment_strong_count(ctx_ptr as *const Self);
+        ctx_ptr
     }
 }
 


### PR DESCRIPTION
`SCNetworkReachabilitySetCallback()` calls `retain_context()` immediately, which increases the ref counter by 1. `Arc::into_raw(callback)` is consuming hence it needs to be balanced with `Arc::from_raw()` after passing the callback pointer to `SCNetworkReachabilitySetCallback()`.

This PR adds the missing call to `Arc::from_raw()` to fix the memory leak in `set_callback()` and upgrades `retain_context` and `release_context` functions to use `increment_strong_count` and `decrement_strong_count` which trims a few lines of code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/system-configuration-rs/35)
<!-- Reviewable:end -->
