### PR TITLE
Add SCNetworkService and SCNetworkSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Added
+- Add bindings for `SCNetworkSet` and `SCNetworkService`
+
 ### Changed
 - Bump minimum supported Rust version to 1.56.0
 


### PR DESCRIPTION
To aid with finding the best default route, I'm planning on relying on the user defined network service order. To do this, I need to add some wrappers for the FFI code to fetch it from the system configuration. 

The changes are fairly plain, and whilst there is a test, which aided in development but I'm not sure if it's worthwhile to have around.


Oh, and it seems like clippy is failing with an ICE :facepalm:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/system-configuration-rs/37)
<!-- Reviewable:end -->
