### PR TITLE
DELETE: deprecated _kSCNetworkInterfaceTypeBridge symbols

### DIFF
--- a/system-configuration-sys/src/network_configuration.rs
+++ b/system-configuration-sys/src/network_configuration.rs
@@ -126,8 +126,6 @@ extern "C" {
 
     pub static kSCNetworkInterfaceTypeBond: CFStringRef;
 
-    pub static kSCNetworkInterfaceTypeBridge: CFStringRef;
-
     pub static kSCNetworkInterfaceTypeEthernet: CFStringRef;
 
     pub static kSCNetworkInterfaceTypeFireWire: CFStringRef;
@@ -135,8 +133,6 @@ extern "C" {
     pub static kSCNetworkInterfaceTypeIEEE80211: CFStringRef;
 
     pub static kSCNetworkInterfaceTypeIPSec: CFStringRef;
-
-    pub static kSCNetworkInterfaceTypeIrDA: CFStringRef;
 
     pub static kSCNetworkInterfaceTypeL2TP: CFStringRef;
 

--- a/system-configuration/src/network_configuration.rs
+++ b/system-configuration/src/network_configuration.rs
@@ -103,8 +103,6 @@ pub enum SCNetworkInterfaceType {
     SixToFour,
     /// Bluetooth interface.
     Bluetooth,
-    /// Bridge interface.
-    Bridge,
     /// Ethernet bond interface.
     Bond,
     /// Ethernet interface.
@@ -115,8 +113,6 @@ pub enum SCNetworkInterfaceType {
     IEEE80211,
     /// IPSec interface.
     IPSec,
-    /// IrDA interface.
-    IrDA,
     /// L2TP interface.
     L2TP,
     /// Modem interface.
@@ -152,8 +148,6 @@ impl SCNetworkInterfaceType {
                 Some(SCNetworkInterfaceType::SixToFour)
             } else if id_is_equal_to(kSCNetworkInterfaceTypeBluetooth) {
                 Some(SCNetworkInterfaceType::Bluetooth)
-            } else if id_is_equal_to(kSCNetworkInterfaceTypeBridge) {
-                Some(SCNetworkInterfaceType::Bridge)
             } else if id_is_equal_to(kSCNetworkInterfaceTypeBond) {
                 Some(SCNetworkInterfaceType::Bond)
             } else if id_is_equal_to(kSCNetworkInterfaceTypeEthernet) {
@@ -164,8 +158,6 @@ impl SCNetworkInterfaceType {
                 Some(SCNetworkInterfaceType::IEEE80211)
             } else if id_is_equal_to(kSCNetworkInterfaceTypeIPSec) {
                 Some(SCNetworkInterfaceType::IPSec)
-            } else if id_is_equal_to(kSCNetworkInterfaceTypeIrDA) {
-                Some(SCNetworkInterfaceType::IrDA)
             } else if id_is_equal_to(kSCNetworkInterfaceTypeL2TP) {
                 Some(SCNetworkInterfaceType::L2TP)
             } else if id_is_equal_to(kSCNetworkInterfaceTypeModem) {


### PR DESCRIPTION
I'm doing this pull request to bring to your attention that Apple has deprecated the _kSCNetworkInterfaceTypeBridge symbols.

Source:
https://developer.apple.com/documentation/systemconfiguration/scnetworkconfiguration/network_interface_types?language=objc

Thank You
Quentin

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/system-configuration-rs/38)
<!-- Reviewable:end -->
