### PR TITLE
DELETE: deprecated _kSCNetworkInterfaceTypeBridge symbols

### DIFF
--- a/system-configuration-sys/src/network_configuration.rs
+++ b/system-configuration-sys/src/network_configuration.rs
@@ -126,8 +126,6 @@ extern "C" {
 
     pub static kSCNetworkInterfaceTypeBond: CFStringRef;
 
-    pub static kSCNetworkInterfaceTypeBridge: CFStringRef;
-
     pub static kSCNetworkInterfaceTypeEthernet: CFStringRef;
 
     pub static kSCNetworkInterfaceTypeFireWire: CFStringRef;

--- a/system-configuration/src/network_configuration.rs
+++ b/system-configuration/src/network_configuration.rs
@@ -103,8 +103,6 @@ pub enum SCNetworkInterfaceType {
     SixToFour,
     /// Bluetooth interface.
     Bluetooth,
-    /// Bridge interface.
-    Bridge,
     /// Ethernet bond interface.
     Bond,
     /// Ethernet interface.
@@ -152,8 +150,6 @@ impl SCNetworkInterfaceType {
                 Some(SCNetworkInterfaceType::SixToFour)
             } else if id_is_equal_to(kSCNetworkInterfaceTypeBluetooth) {
                 Some(SCNetworkInterfaceType::Bluetooth)
-            } else if id_is_equal_to(kSCNetworkInterfaceTypeBridge) {
-                Some(SCNetworkInterfaceType::Bridge)
             } else if id_is_equal_to(kSCNetworkInterfaceTypeBond) {
                 Some(SCNetworkInterfaceType::Bond)
             } else if id_is_equal_to(kSCNetworkInterfaceTypeEthernet) {


### PR DESCRIPTION
I'm doing this pull request to bring to your attention that Apple has deprecated the _kSCNetworkInterfaceTypeBridge symbols.

Source:
https://developer.apple.com/documentation/systemconfiguration/scnetworkconfiguration/network_interface_types?language=objc

Thank You
Quentin
 