### PR TITLE
Prepare 0.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+
+
+## [0.5.1] - 2023-05-15
 ### Added
 - Add bindings for `SCNetworkSet` and `SCNetworkService`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,13 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - Add bindings for `SCNetworkSet` and `SCNetworkService`
 
+
+## [0.5.0] - 2022-01-03
 ### Changed
-- Bump minimum supported Rust version to 1.56.0
+- Upgrade crates to Rust 2021 edition.
+- Bump minimum supported Rust version (MSRV) to 1.56.0.
+- Upgrade core-foundation to 0.9 and core-foundation-sys to 0.8. This is a breaking
+  change since those crates are publicly re-exported from these crates.
 
 
 ## [0.4.1] - 2020-06-04

--- a/system-configuration-sys/Cargo.toml
+++ b/system-configuration-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "system-configuration-sys"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Mullvad VPN"]
 description = "Low level bindings to SystemConfiguration framework for macOS"
 keywords = ["macos", "system", "configuration", "bindings"]

--- a/system-configuration/Cargo.toml
+++ b/system-configuration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "system-configuration"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Mullvad VPN"]
 description = "Bindings to SystemConfiguration framework for macOS"
 keywords = ["macos", "system", "configuration", "bindings"]

--- a/system-configuration/Cargo.toml
+++ b/system-configuration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "system-configuration"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Mullvad VPN"]
 description = "Bindings to SystemConfiguration framework for macOS"
 keywords = ["macos", "system", "configuration", "bindings"]
@@ -12,5 +12,5 @@ edition = "2021"
 
 [dependencies]
 core-foundation = "0.9"
-system-configuration-sys = { path = "../system-configuration-sys", version = "0.4" }
+system-configuration-sys = { path = "../system-configuration-sys", version = "0.5" }
 bitflags = "1"

--- a/system-configuration/src/lib.rs
+++ b/system-configuration/src/lib.rs
@@ -19,8 +19,10 @@
 
 #![deny(missing_docs)]
 
+/// CoreFoundation wrappers
 #[macro_use]
 pub extern crate core_foundation;
+/// Low-level SystemConfiguration bindings
 pub extern crate system_configuration_sys as sys;
 
 pub mod dynamic_store;


### PR DESCRIPTION
The only change is add functionality (for network sets/services). Nothing breaking is introduced. So I've bumped the version to 0.5.1.

I've also cherry-picked the version and changelog updates from the `release-0.5.0` branch, since they were missing on `main`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/system-configuration-rs/40)
<!-- Reviewable:end -->
