### PR TITLE
Remove deprecated IrDA variant and private _kSCNetworkInterfaceTypeBridge reference

### DIFF
--- a/system-configuration-sys/src/network_configuration.rs
+++ b/system-configuration-sys/src/network_configuration.rs
@@ -126,8 +126,6 @@ extern "C" {
 
     pub static kSCNetworkInterfaceTypeBond: CFStringRef;
 
-    pub static kSCNetworkInterfaceTypeBridge: CFStringRef;
-
     pub static kSCNetworkInterfaceTypeEthernet: CFStringRef;
 
     pub static kSCNetworkInterfaceTypeFireWire: CFStringRef;
@@ -135,8 +133,6 @@ extern "C" {
     pub static kSCNetworkInterfaceTypeIEEE80211: CFStringRef;
 
     pub static kSCNetworkInterfaceTypeIPSec: CFStringRef;
-
-    pub static kSCNetworkInterfaceTypeIrDA: CFStringRef;
 
     pub static kSCNetworkInterfaceTypeL2TP: CFStringRef;
 

--- a/system-configuration/src/network_configuration.rs
+++ b/system-configuration/src/network_configuration.rs
@@ -115,8 +115,8 @@ pub enum SCNetworkInterfaceType {
     IEEE80211,
     /// IPSec interface.
     IPSec,
-    /// IrDA interface.
-    IrDA,
+    // IrDA interface.
+    //IrDA,
     /// L2TP interface.
     L2TP,
     /// Modem interface.
@@ -164,8 +164,8 @@ impl SCNetworkInterfaceType {
                 Some(SCNetworkInterfaceType::IEEE80211)
             } else if id_is_equal_to(kSCNetworkInterfaceTypeIPSec) {
                 Some(SCNetworkInterfaceType::IPSec)
-            } else if id_is_equal_to(kSCNetworkInterfaceTypeIrDA) {
-                Some(SCNetworkInterfaceType::IrDA)
+            //} else if id_is_equal_to(kSCNetworkInterfaceTypeIrDA) {
+                //Some(SCNetworkInterfaceType::IrDA)
             } else if id_is_equal_to(kSCNetworkInterfaceTypeL2TP) {
                 Some(SCNetworkInterfaceType::L2TP)
             } else if id_is_equal_to(kSCNetworkInterfaceTypeModem) {

--- a/system-configuration/src/network_configuration.rs
+++ b/system-configuration/src/network_configuration.rs
@@ -103,8 +103,6 @@ pub enum SCNetworkInterfaceType {
     SixToFour,
     /// Bluetooth interface.
     Bluetooth,
-    /// Bridge interface.
-    Bridge,
     /// Ethernet bond interface.
     Bond,
     /// Ethernet interface.
@@ -152,8 +150,6 @@ impl SCNetworkInterfaceType {
                 Some(SCNetworkInterfaceType::SixToFour)
             } else if id_is_equal_to(kSCNetworkInterfaceTypeBluetooth) {
                 Some(SCNetworkInterfaceType::Bluetooth)
-            } else if id_is_equal_to(kSCNetworkInterfaceTypeBridge) {
-                Some(SCNetworkInterfaceType::Bridge)
             } else if id_is_equal_to(kSCNetworkInterfaceTypeBond) {
                 Some(SCNetworkInterfaceType::Bond)
             } else if id_is_equal_to(kSCNetworkInterfaceTypeEthernet) {


### PR DESCRIPTION
Fixes for publishing iOS apps that have `system-configuration` in their dependency tree.

Closes #41 and closes #39.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/system-configuration-rs/42)
<!-- Reviewable:end -->
