### PR TITLE
Mark schedule_with_runloop/unschedule_from_runloop as unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Line wrap the file at 100 chars.                                              Th
 ## [Unreleased]
 ### Changed
 - Bump minimum supported Rust version (MSRV) to 1.64.0.
+- Breaking: Mark `SCNetworkReachability::schedule_with_runloop` and `unschedule_from_runloop` as
+  `unsafe`. They accept a raw pointer that it dereferences. Figuring out a safe API around this is
+  left as an exercise for the future.
 
 ### Fixed
 - Fix memory leak in `SCNetworkReachability::set_callback`.

--- a/system-configuration/src/network_reachability.rs
+++ b/system-configuration/src/network_reachability.rs
@@ -186,7 +186,12 @@ impl SCNetworkReachability {
     /// See [`SCNetworkReachabilityScheduleFromRunLoop`] for details.
     ///
     /// [`SCNetworkReachabilityScheduleFromRunLoop`]: https://developer.apple.com/documentation/systemconfiguration/1514894-scnetworkreachabilityschedulewit?language=objc
-    pub fn schedule_with_runloop(
+    ///
+    /// # Safety
+    ///
+    /// The `run_loop_mode` must not be NULL and must be a pointer to a valid run loop mode.
+    /// Use `core_foundation::runloop::kCFRunLoopCommonModes` if you are unsure.
+    pub unsafe fn schedule_with_runloop(
         &self,
         run_loop: &CFRunLoop,
         run_loop_mode: CFStringRef,
@@ -210,7 +215,12 @@ impl SCNetworkReachability {
     /// See [`SCNetworkReachabilityUnscheduleFromRunLoop`] for details.
     ///
     /// [`SCNetworkReachabilityUnscheduleFromRunLoop`]: https://developer.apple.com/documentation/systemconfiguration/1514899-scnetworkreachabilityunschedulef?language=objc
-    pub fn unschedule_from_runloop(
+    ///
+    /// # Safety
+    ///
+    /// The `run_loop_mode` must not be NULL and must be a pointer to a valid run loop mode.
+    /// Use `core_foundation::runloop::kCFRunLoopCommonModes` if you are unsure.
+    pub unsafe fn unschedule_from_runloop(
         &self,
         run_loop: &CFRunLoop,
         run_loop_mode: CFStringRef,


### PR DESCRIPTION
This is an API breaking change. Mark `SCNetworkReachability::schedule_with_runloop` and `unschedule_from_runloop` as `unsafe`. They accept a raw pointer that it dereferences (this library does not, but it's passed on to Apple libraries that might).

Figuring out a safe API around this is left as an exercise for the future or external contributors.