### PR TITLE
Derive `ReachabilityFlags` traits (that were removed by bitflags upgrade)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Line wrap the file at 100 chars.                                              Th
 - Breaking: Mark `SCNetworkReachability::schedule_with_runloop` and `unschedule_from_runloop` as
   `unsafe`. They accept a raw pointer that it dereferences. Figuring out a safe API around this is
   left as an exercise for the future.
+- Breaking: `ReachabilityFlags` no longer implements `Ord` or `PartialOrd`. It also replaces the
+  `from_bits_unchecked` constructor with other (safe) `from_bits_*` constructors.
 
 ### Fixed
 - Fix memory leak in `SCNetworkReachability::set_callback`.

--- a/system-configuration/src/network_reachability.rs
+++ b/system-configuration/src/network_reachability.rs
@@ -85,6 +85,7 @@ bitflags::bitflags! {
     /// Rustier interface for [`SCNetworkReachabilityFlags`].
     ///
     /// [`SCNetworkReachability`]: https://developer.apple.com/documentation/systemconfiguration/scnetworkreachabilityflags
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct ReachabilityFlags: u32 {
         /// The specified node name or address can be reached via a transient connection, such as
         /// PPP.


### PR DESCRIPTION
The upgrade of `bitflags` from `1` to `2` in #45 removed a lot of automatically derived traits. I found this with `cargo semver-checks`. This PR adds many of them back! Because these derivations make sense. However, we still lose the derivation of `Ord` and `PartialOrd` that `bitflags 1` automatically derived. This is fine to lose however, since ordering of flags did not make much sense. It is a breaking change nonetheless.

The bitflags upgrade also replaces an unsafe constructor with a bunch of safe ones.

Also add the changelog entry for this upgrade.