### PR TITLE
Bump version and add changelog header for 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,12 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
-- Fix `std::net::SocketAddr` conversion to `libc::sockaddr`
+
+## [0.6.1] - 2024-08-22
+### Fixed
+- Fix `std::net::SocketAddr` conversion to `libc::sockaddr`. This makes `SCNetworkReachability`
+  reachability check work for other addresses than only `0.0.0.0:0`.
+
 
 ## [0.6.0] - 2024-01-31
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "system-configuration"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bitflags",
  "core-foundation",

--- a/system-configuration/Cargo.toml
+++ b/system-configuration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "system-configuration"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Mullvad VPN"]
 description = "Bindings to SystemConfiguration framework for macOS"
 keywords = ["macos", "system", "configuration", "bindings"]


### PR DESCRIPTION
Just a patch release with the fix to `SCNetworkReachability` really.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/system-configuration-rs/58)
<!-- Reviewable:end -->
