### PR TITLE
Added `null` checks to dynamic store APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - Added `std::error::Error` implementation for `ReachabilityError`.
 
+### Fixed
+- Handle errors that may occur when creating runloop sources or an `SCDynamicStore`.
+
+
 ## [0.6.1] - 2024-08-22
 ### Fixed
 - Fix `std::net::SocketAddr` conversion to `libc::sockaddr`. This makes `SCNetworkReachability`

--- a/system-configuration/examples/set_dns.rs
+++ b/system-configuration/examples/set_dns.rs
@@ -14,7 +14,9 @@ use system_configuration::{
 // network interface to 8.8.8.8 and 8.8.4.4
 
 fn main() {
-    let store = SCDynamicStoreBuilder::new("my-test-dyn-store").build();
+    let store = SCDynamicStoreBuilder::new("my-test-dyn-store")
+        .build()
+        .expect("Unable to create DynamicStore");
     let primary_service_uuid = get_primary_service_uuid(&store).expect("No PrimaryService active");
     println!("PrimaryService UUID: {}", primary_service_uuid);
 

--- a/system-configuration/examples/watch_dns.rs
+++ b/system-configuration/examples/watch_dns.rs
@@ -22,7 +22,8 @@ fn main() {
 
     let store = SCDynamicStoreBuilder::new("my-watch-dns-store")
         .callback_context(callback_context)
-        .build();
+        .build()
+        .expect("Unable to create DynamicStore");
 
     let watch_keys: CFArray<CFString> = CFArray::from_CFTypes(&[]);
     let watch_patterns =
@@ -34,7 +35,9 @@ fn main() {
         panic!("Unable to register notifications");
     }
 
-    let run_loop_source = store.create_run_loop_source();
+    let run_loop_source = store
+        .create_run_loop_source()
+        .expect("Unable to create run loop source");
     let run_loop = CFRunLoop::get_current();
     run_loop.add_source(&run_loop_source, unsafe { kCFRunLoopCommonModes });
 

--- a/system-configuration/src/dynamic_store.rs
+++ b/system-configuration/src/dynamic_store.rs
@@ -102,7 +102,7 @@ impl<T> SCDynamicStoreBuilder<T> {
     }
 
     /// Create the dynamic store session.
-    pub fn build(mut self) -> SCDynamicStore {
+    pub fn build(mut self) -> Option<SCDynamicStore> {
         let store_options = self.create_store_options();
         if let Some(callback_context) = self.callback_context.take() {
             SCDynamicStore::create(
@@ -161,7 +161,7 @@ impl SCDynamicStore {
         store_options: &CFDictionary,
         callout: SCDynamicStoreCallBack,
         context: *mut SCDynamicStoreContext,
-    ) -> Self {
+    ) -> Option<Self> {
         unsafe {
             let store = SCDynamicStoreCreateWithOptions(
                 kCFAllocatorDefault,
@@ -170,7 +170,11 @@ impl SCDynamicStore {
                 callout,
                 context,
             );
-            SCDynamicStore::wrap_under_create_rule(store)
+            if store.is_null() {
+                None
+            } else {
+                Some(SCDynamicStore::wrap_under_create_rule(store))
+            }
         }
     }
 
@@ -185,10 +189,10 @@ impl SCDynamicStore {
                 self.as_concrete_TypeRef(),
                 cf_pattern.as_concrete_TypeRef(),
             );
-            if !array_ref.is_null() {
-                Some(CFArray::wrap_under_create_rule(array_ref))
-            } else {
+            if array_ref.is_null() {
                 None
+            } else {
+                Some(CFArray::wrap_under_create_rule(array_ref))
             }
         }
     }
@@ -268,14 +272,18 @@ impl SCDynamicStore {
     }
 
     /// Creates a run loop source object that can be added to the application's run loop.
-    pub fn create_run_loop_source(&self) -> CFRunLoopSource {
+    pub fn create_run_loop_source(&self) -> Option<CFRunLoopSource> {
         unsafe {
             let run_loop_source_ref = SCDynamicStoreCreateRunLoopSource(
                 kCFAllocatorDefault,
                 self.as_concrete_TypeRef(),
                 0,
             );
-            CFRunLoopSource::wrap_under_create_rule(run_loop_source_ref)
+            if run_loop_source_ref.is_null() {
+                None
+            } else {
+                Some(CFRunLoopSource::wrap_under_create_rule(run_loop_source_ref))
+            }
         }
     }
 }


### PR DESCRIPTION
We noticed crashes due to missing `null` checks in `dynamic_store.rs`.

Additional background:
`SCDynamicStoreCreate` / `SCDynamicStoreCreateWithOptions` can return `null`. The returned value is currently passed to `wrap_under_create_rule` without a `null` check, which [leads to an assertion error](https://github.com/servo/core-foundation-rs/blob/b2fdaf4132a8fff7aadd6885ec7c570296a664ea/core-foundation/src/lib.rs#L115) (`Attempted to create a NULL object`).

This PR adds additional checks and modifies affected APIs to return an `Option` instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/system-configuration-rs/59)
<!-- Reviewable:end -->
