### PR TITLE
Implemented std::error::Error for ReachabilityError.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Line wrap the file at 100 chars.                                              Th
 
 ## [Unreleased]
 
+### Added
+- Added `std::error::Error` implementation for `ReachabilityError`.
+
 ## [0.6.1] - 2024-08-22
 ### Fixed
 - Fix `std::net::SocketAddr` conversion to `libc::sockaddr`. This makes `SCNetworkReachability`

--- a/system-configuration/src/network_reachability.rs
+++ b/system-configuration/src/network_reachability.rs
@@ -42,6 +42,19 @@ pub enum ReachabilityError {
     UnrecognizedFlags(u32),
 }
 
+impl Display for ReachabilityError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::FailedToDetermineReachability => write!(f, "Failed to determine reachability"),
+            Self::UnrecognizedFlags(flags) => {
+                write!(f, "Unrecognized reachability flags: {}", flags)
+            }
+        }
+    }
+}
+
+impl Error for ReachabilityError {}
+
 /// Failure to schedule a reachability callback on a runloop.
 #[derive(Debug)]
 pub struct SchedulingError(());


### PR DESCRIPTION
All other error types in `system-configuration/src/network_reachability.rs` conform to `std::error:Error` but `ReachabilityError` seems by coincidence does not conform to it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/system-configuration-rs/60)
<!-- Reviewable:end -->
