### PR TITLE
Handle NULL pointers from SC APIs in sandboxed environments

### DIFF
--- a/system-configuration/Cargo.toml
+++ b/system-configuration/Cargo.toml
@@ -12,6 +12,6 @@ edition = "2021"
 rust-version = "1.64.0"
 
 [dependencies]
-core-foundation = "0.9"
+core-foundation = "0.10"
 system-configuration-sys = { path = "../system-configuration-sys", version = "0.6" }
 bitflags = "2"

--- a/system-configuration/src/dynamic_store.rs
+++ b/system-configuration/src/dynamic_store.rs
@@ -103,7 +103,7 @@ impl<T> SCDynamicStoreBuilder<T> {
 
     /// Create the dynamic store session.
     pub fn build(mut self) -> Option<SCDynamicStore> {
-        let store_options = self.create_store_options();
+        let store_options = self.create_store_options()?;
         if let Some(callback_context) = self.callback_context.take() {
             SCDynamicStore::create(
                 &self.name,
@@ -116,11 +116,12 @@ impl<T> SCDynamicStoreBuilder<T> {
         }
     }
 
-    fn create_store_options(&self) -> CFDictionary {
-        let key = unsafe { CFString::wrap_under_create_rule(kSCDynamicStoreUseSessionKeys) };
+    fn create_store_options(&self) -> Option<CFDictionary> {
+        let key =
+            unsafe { CFString::try_wrap_under_create_rule(kSCDynamicStoreUseSessionKeys) }?;
         let value = CFBoolean::from(self.session_keys);
         let typed_dict = CFDictionary::from_CFType_pairs(&[(key, value)]);
-        unsafe { CFDictionary::wrap_under_get_rule(typed_dict.as_concrete_TypeRef()) }
+        unsafe { CFDictionary::try_wrap_under_get_rule(typed_dict.as_concrete_TypeRef()) }
     }
 
     fn create_context(

--- a/system-configuration/src/preferences.rs
+++ b/system-configuration/src/preferences.rs
@@ -26,7 +26,7 @@ impl_TCFType!(SCPreferences, SCPreferencesRef, SCPreferencesGetTypeID);
 
 impl SCPreferences {
     /// Initiates access to the default system preferences using the default allocator.
-    pub fn default(calling_process_name: &CFString) -> Self {
+    pub fn default(calling_process_name: &CFString) -> Option<Self> {
         Self::new(None, calling_process_name, None)
     }
 
@@ -35,7 +35,7 @@ impl SCPreferences {
     /// constructor.
     ///
     /// [`default`]: #method.default
-    pub fn group(calling_process_name: &CFString, prefs_id: &CFString) -> Self {
+    pub fn group(calling_process_name: &CFString, prefs_id: &CFString) -> Option<Self> {
         Self::new(None, calling_process_name, Some(prefs_id))
     }
 
@@ -51,7 +51,7 @@ impl SCPreferences {
         allocator: Option<&CFAllocator>,
         calling_process_name: &CFString,
         prefs_id: Option<&CFString>,
-    ) -> Self {
+    ) -> Option<Self> {
         let allocator_ref = match allocator {
             Some(allocator) => allocator.as_concrete_TypeRef(),
             None => ptr::null(),
@@ -62,7 +62,7 @@ impl SCPreferences {
         };
 
         unsafe {
-            SCPreferences::wrap_under_create_rule(SCPreferencesCreate(
+            SCPreferences::try_wrap_under_create_rule(SCPreferencesCreate(
                 allocator_ref,
                 calling_process_name.as_concrete_TypeRef(),
                 prefs_id_ref,
@@ -77,7 +77,7 @@ mod tests {
 
     #[test]
     fn retain_count() {
-        let preferences = SCPreferences::default(&CFString::new("test"));
+        let preferences = SCPreferences::default(&CFString::new("test")).unwrap();
         assert_eq!(preferences.retain_count(), 1);
     }
 }


### PR DESCRIPTION
## Summary

- Use fallible `try_wrap_under_create_rule` / `try_wrap_under_get_rule` at all unsafe CF call sites so that NULL returns are handled gracefully instead of panicking
- `SCPreferences::new` / `default` / `group` now return `Option<Self>`
- `SCDynamicStoreBuilder::build()` propagates `None` when store options fail
- `SCNetworkReachability::from_addr_pair` returns `Option`
- `From<SocketAddr>` replaced with `TryFrom<SocketAddr>` (with `NetworkReachabilityCreateError`)
- `get_interfaces()` returns `Option<CFArray<SCNetworkInterface>>`
- `SCNetworkSet::new()` returns `Option<Self>`
- `SCNetworkInterfaceType::from_cfstring` uses `try_wrap_under_get_rule` and returns `false` on `None`
- Bumps `core-foundation` dependency to `0.10`

## Motivation

In macOS sandboxed environments (e.g. App Sandbox, `sandbox-exec`), several SystemConfiguration and CoreFoundation API calls return NULL pointers. The `impl_TCFType!` macro's `wrap_under_create_rule` and `wrap_under_get_rule` contain `assert!(!reference.is_null())`, which causes a panic instead of allowing callers to handle the error.

This is a **breaking change** to the public API since several methods now return `Option` or `Result` instead of the bare type.

## Dependencies

This PR depends on https://github.com/servo/core-foundation-rs/pull/748 which adds the `try_wrap_under_create_rule` and `try_wrap_under_get_rule` default methods to the `TCFType` trait in `core-foundation`. This PR cannot be merged until that upstream change is released.

## Test plan

- [x] `cargo build` passes (with local path dep to core-foundation fork)
- [x] All tests pass except two pre-existing environment-dependent failures
- [x] Verified in sandbox: calls that return NULL now produce `None` instead of panicking

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/system-configuration-rs/74)
<!-- Reviewable:end -->
